### PR TITLE
Implementation of LC.InterfaceQueryViewScale()

### DIFF
--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -108,6 +108,6 @@ else
 fi
 
 # Cleanup
-if [ -f "$LIVECODE_DEP_FILE.tmp"]
+if [ -f "$LIVECODE_DEP_FILE.tmp"]; then
     rm "$LIVECODE_DEP_FILE.tmp"
 fi

--- a/lcidlc/src/InterfaceGenerate.cpp
+++ b/lcidlc/src/InterfaceGenerate.cpp
@@ -1637,6 +1637,7 @@ static bool InterfaceGenerateExports(InterfaceRef self, CoderRef p_coder)
 		{ "InterfaceQueryActivity", "jobject", nil, nil },
 		{ "InterfaceQueryContainer", "jobject", nil, nil },
 		{ "InterfaceQueryEngine", "jobject", nil, nil },
+		{ "InterfaceQueryViewScale", "jdouble", nil, nil },
 		{ "ObjectResolve", "jlong", "jobject chunk", "chunk" },
 		{ "ObjectRetain", "void", "jlong object", "object" },
 		{ "ObjectRelease", "void", "jlong object", "object" },

--- a/lcidlc/src/Support.java
+++ b/lcidlc/src/Support.java
@@ -279,6 +279,11 @@ public class LC
 	{
 		return getEngineApi() . getContainer();
 	}
+    
+    public static double InterfaceQueryViewScale()
+    {
+        return __InterfaceQueryViewScale();
+    }
 	
 	//////////
 	
@@ -369,4 +374,5 @@ public class LC
 	
 	//private static native Activity __InterfaceQueryActivity();
 	//private static native ViewGroup __InterfaceQueryContainer();
+    private static native double __InterfaceQueryViewScale();
 };

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -3510,6 +3510,19 @@ static jobject java_lcapi_InterfaceQueryEngine(JNIEnv *env)
 {
 	return java__get_engine();
 }
+    
+static jdouble java_lcapi_InterfaceQueryViewScale(JNIEnv *env)
+{
+    LCError t_error;
+    double t_scale;
+    t_error = LCInterfaceQueryViewScale(&t_scale);
+    if (t_error != kLCErrorNone)
+    {
+        java_lcapi__throw(env, t_error);
+        return (jdouble)0.0;
+    }
+    return (jdouble)t_scale;
+}
 
 static void java_lcapi_RunOnSystemThread_callback(void *context)
 {


### PR DESCRIPTION
This pull request relates to the one I just sent against the develop branch making LCInterfaceQueryViewScale cross platform. We may want to look at adding an interface to get the transform being applied to the stack to handle stretched views which we can then apply to our native views.
