### PR TITLE
Feature/externals v5

### DIFF
--- a/lcidlc/lclink.sh
+++ b/lcidlc/lclink.sh
@@ -14,7 +14,7 @@ if [ -f "$LIVECODE_DEP_FILE" ]; then
     DEPS=$(cat "$LIVECODE_DEP_FILE")
 
     # Frameworks may not exist in older sdks so conditionally include
-    for MAJORVERSION in 3 4 5 6 7; do
+    for MAJORVERSION in 3 4 5 6 7 8 9 10; do
         for MINORVERSION in 0 1 2 3 4; do
             if [[ $SDK_MAJORVERSION -lt $MAJORVERSION || ($SDK_MAJORVERSION == $MAJORVERSION && $SDK_MINORVERSION -lt $MINORVERSION) ]]; then
                 DEPS="$(sed "/framework-$MAJORVERSION\.$MINORVERSION /d" <<< "$DEPS")"

--- a/lcidlc/src/Support.mm
+++ b/lcidlc/src/Support.mm
@@ -1645,6 +1645,14 @@ static MCError LCArgumentsCreateV(const char *p_signature, va_list p_args, MCVar
 				t_string . length = [t_data length];
 				t_error = MCVariableStore(t_argv[i], kMCOptionAsString, &t_string);
 			}
+            break;
+                
+            case 'O': // Any supported Objective-C object
+            {
+                id t_object;
+                t_object = va_arg(p_args, id);
+                t_error = (MCError) LCValueArrayValueFromObjcValue(t_argv[i], t_object);
+            }
 			break;
 #endif
 		}


### PR DESCRIPTION
Not sure if type N,S & D should be deprecated and we just use continuation to handle all 4 cases with the type O script as LCValueArrayValueFromObjcValue appears to set scalars when appropriate.
