### PR TITLE
[[ Windows ]] Fix linking of engine lcb modules in Windows release mode

### DIFF
--- a/toolchain/lc-compile/src/emit.cpp
+++ b/toolchain/lc-compile/src/emit.cpp
@@ -482,7 +482,7 @@ EmitEndModuleOutputC (NameRef p_module_name,
 	if (0 > fprintf(t_file, "static __builtin_module_info __%s_module_info = {\n    0,\n    0,\n    %s_module_data,\n    sizeof(%s_module_data),\n    %s_Initialize,\n    %s_Finalize };\n", t_modified_name, t_modified_name, t_modified_name, t_modified_name, t_modified_name))
 		goto error_cleanup;
     
-    if (0 > fprintf(t_file, "static __builtin_module_loader __%s_loader(&__%s_module_info);\n\n", t_modified_name, t_modified_name))
+    if (0 > fprintf(t_file, "__builtin_module_loader __%s_loader(&__%s_module_info);\n\n", t_modified_name, t_modified_name))
         goto error_cleanup;
     
     EmittedModule *t_mod;


### PR DESCRIPTION
This patch changes the export type of the loader classes in
embedded LCB modules (output C mode) to be non-static. This appears
to fix a problem with them not being linked into a release mode
executable on Windows.